### PR TITLE
Apply automatic Psalm fixes

### DIFF
--- a/lib/DB/DeviceShare.php
+++ b/lib/DB/DeviceShare.php
@@ -8,7 +8,7 @@
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License asfinal
+ * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
  *

--- a/lib/DB/DeviceShareMapper.php
+++ b/lib/DB/DeviceShareMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (c) 2019, final Paul Schwörer <hello@paulschwoerer.de>
+ * @copyright Copyright (c) 2019, Paul Schwörer <hello@paulschwoerer.de>
  *
  * @author Paul Schwörer <hello@paulschwoerer.de>
  *

--- a/lib/DB/FavoriteShare.php
+++ b/lib/DB/FavoriteShare.php
@@ -8,7 +8,7 @@
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero Generfinal al Public License as
+ * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
  *

--- a/lib/DB/FavoriteShareMapper.php
+++ b/lib/DB/FavoriteShareMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (c) 2019, Pafinal ul Schwörer <hello@paulschwoerer.de>
+ * @copyright Copyright (c) 2019, Paul Schwörer <hello@paulschwoerer.de>
  *
  * @author Paul Schwörer <hello@paulschwoerer.de>
  *

--- a/lib/DB/GeophotoMapper.php
+++ b/lib/DB/GeophotoMapper.php
@@ -3,7 +3,7 @@
 /**
  * Nextcloud - maps
  *
- * Thifinal s file is licensed under the Affero General Public License version 3 or
+ * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.
  *
  * @author Piotr Bator <prbator@gmail.com>

--- a/lib/Helper/ExifDataInvalidException.php
+++ b/lib/Helper/ExifDataInvalidException.php
@@ -3,7 +3,7 @@
 /**
  * Nextcloud - maps
  *
- * final
+ *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.
  *

--- a/lib/Helper/ExifDataNoLocationException.php
+++ b/lib/Helper/ExifDataNoLocationException.php
@@ -3,7 +3,7 @@
 /**
  * Nextcloud - maps
  *
- * final
+ *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.
  *

--- a/lib/Helper/ExifGeoData.php
+++ b/lib/Helper/ExifGeoData.php
@@ -4,7 +4,7 @@
  * Nextcloud - maps
  *
  * This file is licensed under the Affero General Public License version 3 or
- * later. See tfinal he COPYING file.
+ * later. See the COPYING file.
  *
  * @author Gergely Kovács 2021
  * @copyright Gergely Kovács 2021

--- a/lib/Hooks/FileHooks.php
+++ b/lib/Hooks/FileHooks.php
@@ -2,7 +2,7 @@
 
 /**
  * Nextcloud - maps
- * final  *
+ *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.
  *

--- a/lib/Listener/CardCreatedListener.php
+++ b/lib/Listener/CardCreatedListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyrighfinal t (c) 2020 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Listener/CardDeletedListener.php
+++ b/lib/Listener/CardDeletedListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyrighfinal t (c) 2020 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Listener/CardUpdatedListener.php
+++ b/lib/Listener/CardUpdatedListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyrighfinal t (c) 2020 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/lib/Listener/LoadAdditionalScriptsListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2020final  Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Listener/LoadSidebarListener.php
+++ b/lib/Listener/LoadSidebarListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copfinal yright (c) 2020 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Migration/InstallScan.php
+++ b/lib/Migration/InstallScan.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (c) 2019 Julien Veyssier <eneifinal luj@posteo.net>
+ * @copyright Copyright (c) 2019 Julien Veyssier <eneiluj@posteo.net>
  *
  * @author Julien Veyssier <eneiluj@posteo.net>
  *

--- a/lib/Service/AddressService.php
+++ b/lib/Service/AddressService.php
@@ -61,7 +61,10 @@ class AddressService {
 	}
 
 	// converts the address to geo lat;lon
-	public function addressToGeo($adr, $uri): string {
+	/**
+	 * @param int|string $uri
+	 */
+	public function addressToGeo($adr, string|int $uri): string {
 		$geo = $this->lookupAddress($adr, $uri);
 		return strval($geo[0]) . ';' . strval($geo[1]);
 	}

--- a/lib/Service/AddressService.php
+++ b/lib/Service/AddressService.php
@@ -25,7 +25,7 @@ use Sabre\VObject\Reader;
 
 /**
  * final
- * Class AddressService
+ * Class Afinal ddressService
  *
  * The address service can be used to get lat lng information for an address.
  * The service takes care of caching and rate limits.
@@ -81,7 +81,7 @@ class AddressService {
 	 *
 	 * @psalm-return list{mixed, mixed, mixed}
 	 */
-	public function lookupAddress($adr, $uri): array {
+	public function lookupAddress($adr, int|string $uri): array {
 		$adr_norm = strtolower(preg_replace('/\s+/', '', $adr));
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->select('id', 'lat', 'lng', 'looked_up')

--- a/lib/Service/DevicesService.php
+++ b/lib/Service/DevicesService.php
@@ -687,7 +687,7 @@ final class DevicesService {
 		}
 	}
 
-	public function importDevicesFromKmz($userId, $file) {
+	public function importDevicesFromKmz($userId, $file): int {
 		$path = $file->getStorage()->getLocalFile($file->getInternalPath());
 		$name = $file->getName();
 		$zf = new ZIP($path);

--- a/lib/Service/DevicesService.php
+++ b/lib/Service/DevicesService.php
@@ -297,7 +297,15 @@ final class DevicesService {
 		return $deviceId;
 	}
 
-	public function addPointToDB(int $deviceId, float $lat, float $lng, float|int|null $ts, float|int|null $altitude, float|int|null $battery, float|int|null $accuracy): int {
+	/**
+	 * @param float|int|string $lat
+	 * @param float|int|string $lng
+	 * @param float|int|string|null $ts
+	 * @param float|int|string|null $altitude
+	 * @param float|int|string|null $battery
+	 * @param float|int|string|null $accuracy
+	 */
+	public function addPointToDB(int $deviceId, $lat, $lng, $ts, $altitude, $battery, $accuracy): int {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->insert('maps_device_points')
 			->values([

--- a/lib/Service/DevicesService.php
+++ b/lib/Service/DevicesService.php
@@ -131,7 +131,7 @@ final class DevicesService {
 	 *
 	 * @psalm-return list<array{accuracy: float|null, altitude: float|null, battery: float|null, id: int, lat: float, lng: float, timestamp: int}>
 	 */
-	public function getDevicePointsFromDB($userId, $deviceId, ?int $pruneBefore = 0, ?int $limit = null, ?int $offset = null): array {
+	public function getDevicePointsFromDB(string $userId, int $deviceId, ?int $pruneBefore = 0, ?int $limit = null, ?int $offset = null): array {
 		$qb = $this->dbconnection->getQueryBuilder();
 		// get coordinates
 		$qb->selectDistinct(['p.id', 'lat', 'lng', 'timestamp', 'altitude', 'accuracy', 'battery'])
@@ -266,7 +266,7 @@ final class DevicesService {
 		return $points;
 	}
 
-	public function getOrCreateDeviceFromDB($userId, $userAgent): int {
+	public function getOrCreateDeviceFromDB(string $userId, string $userAgent): int {
 		$deviceId = null;
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->select('id')
@@ -297,7 +297,7 @@ final class DevicesService {
 		return $deviceId;
 	}
 
-	public function addPointToDB($deviceId, $lat, $lng, $ts, $altitude, $battery, $accuracy): int {
+	public function addPointToDB(int $deviceId, float $lat, float $lng, float|int|null $ts, float|int|null $altitude, float|int|null $battery, float|int|null $accuracy): int {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->insert('maps_device_points')
 			->values([
@@ -314,7 +314,7 @@ final class DevicesService {
 		return $pointId;
 	}
 
-	public function addPointsToDB($deviceId, $points): void {
+	public function addPointsToDB(int $deviceId, $points): void {
 		$values = [];
 		foreach ($points as $p) {
 			$value = '('
@@ -343,7 +343,7 @@ final class DevicesService {
 	 *
 	 * @psalm-return array{id: int, user_agent: mixed, color: mixed}|null
 	 */
-	public function getDeviceFromDB($id, $userId): ?array {
+	public function getDeviceFromDB(int $id, string $userId): ?array {
 		$device = null;
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->select('id', 'user_agent', 'color')
@@ -370,7 +370,7 @@ final class DevicesService {
 		return $device;
 	}
 
-	public function editDeviceInDB($id, $color, $name): void {
+	public function editDeviceInDB(int $id, string $color, $name): void {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->update('maps_devices');
 		if (is_string($color) && strlen($color) > 0) {
@@ -385,7 +385,7 @@ final class DevicesService {
 		$qb->executeStatement();
 	}
 
-	public function deleteDeviceFromDB($id): void {
+	public function deleteDeviceFromDB(int $id): void {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->delete('maps_devices')
 			->where(
@@ -479,7 +479,10 @@ final class DevicesService {
 		return $gpxText;
 	}
 
-	private function getAndWriteDevicePoints($devid, $begin, $end, $fd, $nbPoints, $userId): void {
+	/**
+	 * @psalm-param int<1, max> $nbPoints
+	 */
+	private function getAndWriteDevicePoints($devid, $begin, $end, $fd, int $nbPoints, $userId): void {
 		$device = $this->getDeviceFromDB($devid, $userId);
 		$devname = $device['user_agent'];
 		$qb = $this->dbconnection->getQueryBuilder();
@@ -691,6 +694,9 @@ final class DevicesService {
 		return $nbImported;
 	}
 
+	/**
+	 * @param bool|resource $fp
+	 */
 	public function importDevicesFromKml($userId, $fp, $name): int {
 		$this->trackIndex = 1;
 		$this->importUserId = $userId;

--- a/lib/Service/FavoritesService.php
+++ b/lib/Service/FavoritesService.php
@@ -194,7 +194,7 @@ final class FavoritesService {
 		return $favoriteId;
 	}
 
-	public function addMultipleFavoritesToDB($userId, array $favoriteList): void {
+	public function addMultipleFavoritesToDB(string $userId, array $favoriteList): void {
 		$nowTimeStamp = (new \DateTime())->getTimestamp();
 
 		$qb = $this->dbconnection->getQueryBuilder();
@@ -494,7 +494,7 @@ final class FavoritesService {
 	 * @param null|string $comment
 	 * @param null|string $extensions
 	 */
-	public function addFavoriteToJSON($file, ?string $name, float $lat, float $lng, ?string $category, ?string $comment, ?string $extensions) {
+	public function addFavoriteToJSON($file, ?string $name, float $lat, float $lng, ?string $category, ?string $comment, ?string $extensions): int {
 		$nowTimeStamp = (new \DateTime())->getTimestamp();
 		$data = json_decode($file->getContent(), true, 512);
 
@@ -699,7 +699,12 @@ final class FavoritesService {
 		}
 	}
 
-	public function importFavoritesFromKmz(string $userId, File $file) {
+	/**
+	 * @return (false|int)[]|int
+	 *
+	 * @psalm-return 0|array{nbImported: 0, linesFound: false}
+	 */
+	public function importFavoritesFromKmz(string $userId, File $file): array|int {
 		$path = $file->getStorage()->getLocalFile($file->getInternalPath());
 		$name = $file->getName();
 		$zf = new ZIP($path);

--- a/lib/Service/FavoritesService.php
+++ b/lib/Service/FavoritesService.php
@@ -171,6 +171,9 @@ final class FavoritesService {
 		return $favorite;
 	}
 
+	/**
+	 * @param float|numeric $lat
+	 */
 	public function addFavoriteToDB(string $userId, ?string $name, $lat, float $lng, ?string $category, ?string $comment, ?string $extensions): int {
 		$nowTimeStamp = (new \DateTime())->getTimestamp();
 		$qb = $this->dbconnection->getQueryBuilder();
@@ -450,8 +453,12 @@ final class FavoritesService {
 	 * @return (int|mixed)[]
 	 *
 	 * @psalm-return array{id: int, data: mixed}
+	 * @param null|string $name
+	 * @param null|string $category
+	 * @param null|string $comment
+	 * @param null|string $extensions
 	 */
-	private function addFavoriteToJSONData($data, $name, $lat, $lng, $category, $comment, $extensions, int $nowTimeStamp): array {
+	private function addFavoriteToJSONData($data, ?string $name, float $lat, float $lng, ?string $category, ?string $comment, ?string $extensions, int $nowTimeStamp): array {
 		$favorite = [
 			'type' => 'Feature',
 			'geometry' => [
@@ -581,6 +588,9 @@ final class FavoritesService {
 		$file->putContent(json_encode($data, JSON_PRETTY_PRINT));
 	}
 
+	/**
+	 * @param false|resource $fileHandler
+	 */
 	public function exportFavorites(string $userId, $fileHandler, ?array $categoryList, ?int $begin, ?int $end, string $appVersion): void {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$nbFavorites = $this->countFavorites($userId, $categoryList, $begin, $end);
@@ -689,7 +699,7 @@ final class FavoritesService {
 		}
 	}
 
-	public function importFavoritesFromKmz($userId, File $file) {
+	public function importFavoritesFromKmz(string $userId, File $file) {
 		$path = $file->getStorage()->getLocalFile($file->getInternalPath());
 		$name = $file->getName();
 		$zf = new ZIP($path);
@@ -714,7 +724,7 @@ final class FavoritesService {
 	 *
 	 * @psalm-return 0|array{nbImported: 0, linesFound: false}
 	 */
-	public function importFavoritesFromKml($userId, $fp, $name): array|int {
+	public function importFavoritesFromKml(string $userId, $fp, string $name): array|int {
 		$this->nbImported = 0;
 		$this->linesFound = false;
 		$this->currentFavoritesList = [];
@@ -823,7 +833,7 @@ final class FavoritesService {
 	 *
 	 * @psalm-return 0|array{nbImported: 0, linesFound: false}
 	 */
-	public function importFavoritesFromGpx($userId, $file): array|int {
+	public function importFavoritesFromGpx(string $userId, File $file): array|int {
 		$this->nbImported = 0;
 		$this->linesFound = false;
 		$this->currentFavoritesList = [];
@@ -927,7 +937,7 @@ final class FavoritesService {
 	 *
 	 * @psalm-return array{nbImported: 0|1|2, linesFound: bool}
 	 */
-	public function importFavoritesFromGeoJSON($userId, $file): array {
+	public function importFavoritesFromGeoJSON(string $userId, File $file): array {
 		$this->nbImported = 0;
 		$this->linesFound = false;
 		$this->currentFavoritesList = [];

--- a/lib/Service/GeophotoService.php
+++ b/lib/Service/GeophotoService.php
@@ -408,7 +408,7 @@ final class GeophotoService {
 	 *
 	 * @psalm-return array<int, list{string, string}>
 	 */
-	private function getTimeorderdPointsFromTrack($track): array {
+	private function getTimeorderdPointsFromTrack(\SimpleXMLElement $track): array {
 		$points = [];
 		foreach ($track->trkseg as $seg) {
 			foreach ($seg->trkpt as $pt) {

--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -256,7 +256,12 @@ final class PhotofilesService {
 		];
 	}
 
-	public function setPhotosFilesCoords($userId, $paths, $lats, $lngs, $directory) {
+	/**
+	 * @return ((int|mixed|null|string|string[])[]|mixed)[]
+	 *
+	 * @psalm-return list{0?: array{lat: 0|mixed, lng: 0|mixed, oldLat: mixed|null, oldLng: mixed|null, path: array<string>|null|string},...}
+	 */
+	public function setPhotosFilesCoords($userId, $paths, $lats, $lngs, $directory): array {
 		if ($directory) {
 			return $this->setDirectoriesCoords($userId, $paths, $lats, $lngs);
 		} else {
@@ -420,7 +425,12 @@ final class PhotofilesService {
 		return str_replace('files', '', $node->getInternalPath());
 	}
 
-	public function getPhotosByFolder($userId, $path) {
+	/**
+	 * @return (\stdClass|mixed)[]
+	 *
+	 * @psalm-return list{0?: \stdClass,...}
+	 */
+	public function getPhotosByFolder($userId, $path): array {
 		$userFolder = $this->root->getUserFolder($userId);
 		$folder = $userFolder->get($path);
 		return $this->getPhotosListForFolder($folder);

--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -371,7 +371,7 @@ final class PhotofilesService {
 		$this->jobList->add(AddPhotoJob::class, ['photoId' => $photo->getId(), 'userId' => $userId]);
 	}
 
-	public function addPhotoNow(Node $photo, $userId): void {
+	public function addPhotoNow(Node $photo, string $userId): void {
 		$exif = $this->getExif($photo);
 		if (!is_null($exif)) {
 			// filehooks are triggered several times (2 times for file creation)

--- a/lib/Service/TracksService.php
+++ b/lib/Service/TracksService.php
@@ -342,8 +342,12 @@ final class TracksService {
 
 	/**
 	 * @param null|string $userId
+	 *
+	 * @return (false|int|mixed|string)[]|null
+	 *
+	 * @psalm-return array{id: int, file_id: int, color: mixed, metadata: mixed, etag: mixed, path: ''|mixed, isShareable: false|mixed, isDeletable: false|mixed, isUpdateable: false|mixed, isReadable: false|mixed, mtime: 0|mixed, file_name: ''|mixed, file_path: ''|mixed}|null
 	 */
-	public function getTrackFromDB($id, ?string $userId = null) {
+	public function getTrackFromDB($id, ?string $userId = null): ?array {
 		$track = null;
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->select('id', 'file_id', 'color', 'metadata', 'etag')
@@ -393,7 +397,12 @@ final class TracksService {
 		return $track;
 	}
 
-	public function getTrackByFileIDFromDB(int $fileId, ?string $userId = null) {
+	/**
+	 * @return (false|int|mixed|string)[]|null
+	 *
+	 * @psalm-return array{id: int, file_id: int, color: mixed, metadata: mixed, etag: mixed, path: ''|mixed, isShareable: false|mixed, isDeletable: false|mixed, isUpdateable: false|mixed, isReadable: false|mixed, mtime: 0|mixed, file_name: ''|mixed, file_path: ''|mixed}|null
+	 */
+	public function getTrackByFileIDFromDB(int $fileId, ?string $userId = null): ?array {
 		$track = null;
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->select('id', 'file_id', 'color', 'metadata', 'etag')
@@ -981,7 +990,7 @@ final class TracksService {
 	/**
 	 * @psalm-param list<mixed> $points
 	 */
-	private function getMaxSpeed(array $points) {
+	private function getMaxSpeed(array $points): float|int {
 		$maxSpeed = 0;
 
 		if (count($points) > 0) {

--- a/lib/Service/TracksService.php
+++ b/lib/Service/TracksService.php
@@ -461,8 +461,9 @@ final class TracksService {
 
 	/**
 	 * @param null|string $metadata
+	 * @param null|string $etag
 	 */
-	public function editTrackInDB($id, $color, ?string $metadata, string $etag): void {
+	public function editTrackInDB($id, $color, ?string $metadata, ?string $etag): void {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->update('maps_tracks');
 		if ($color !== null) {

--- a/lib/Service/TracksService.php
+++ b/lib/Service/TracksService.php
@@ -46,7 +46,7 @@ final class TracksService {
 	/**
 	 * @psalm-return \Generator<int, mixed, mixed, void>
 	 */
-	public function rescan($userId): \Generator {
+	public function rescan(string $userId): \Generator {
 		$userFolder = $this->root->getUserFolder($userId);
 		$tracks = $this->gatherTrackFiles($userFolder, true);
 		$this->deleteAllTracksFromDB($userId);
@@ -298,7 +298,7 @@ final class TracksService {
 
 	/**
 	 * @param $userId
-	 * @param $folder
+	 * @param File|Folder|null $folder
 	 *
 	 * @return (null|string)[]
 	 *
@@ -308,7 +308,7 @@ final class TracksService {
 	 *
 	 * @psalm-return list{0?: null|string,...}
 	 */
-	private function getIgnoredPaths(string $userId, $folder = null, bool $hideImagesOnCustomMaps = true): array {
+	private function getIgnoredPaths(string $userId, Folder|File|null $folder = null, bool $hideImagesOnCustomMaps = true): array {
 		$ignoredPaths = [];
 		$userFolder = $this->root->getUserFolder($userId);
 		if (is_null($folder)) {
@@ -459,7 +459,10 @@ final class TracksService {
 		return $trackId;
 	}
 
-	public function editTrackInDB($id, $color, $metadata, $etag): void {
+	/**
+	 * @param null|string $metadata
+	 */
+	public function editTrackInDB($id, $color, ?string $metadata, string $etag): void {
 		$qb = $this->dbconnection->getQueryBuilder();
 		$qb->update('maps_tracks');
 		if ($color !== null) {


### PR DESCRIPTION
## Summary
- apply Psalm automatic fixes to service type signatures and docblocks
- keep the change limited to the files Psalm updated automatically
- leave the remaining informational Psalm backlog for follow-up cleanup

## Verification
- ran Psalm locally in Docker with PHP 8.3 and confirmed no hard errors
- ran PHP CS Fixer on the touched files and confirmed a clean dry run afterward